### PR TITLE
Use https for license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ GC remove values from `WeakMap`. Proof is available on the first screenshot.
 
 ## License
 
-[The MIT License](http://piecioshka.mit-license.org) @ 2026
+[The MIT License](https://piecioshka.mit-license.org) @ 2026


### PR DESCRIPTION
Switches the README license link from http:// to https://piecioshka.mit-license.org.